### PR TITLE
Fix TCP port range

### DIFF
--- a/custom_components/amshan/__init__.py
+++ b/custom_components/amshan/__init__.py
@@ -59,7 +59,7 @@ TCP_SCHEMA_DICT = {
     vol.Required(CONF_TCP_HOST): vol.Match(
         HOSTNAME_IP4_IP6_REGEX, msg="Must be a valid hostname or ip address."
     ),
-    vol.Required(CONF_TCP_PORT): vol.Range(0, 65353),
+    vol.Required(CONF_TCP_PORT): vol.Range(0, 65535),
 }
 
 SERIAL_SCHEMA = vol.Schema(SERIAL_SCHEMA_DICT)

--- a/custom_components/amshan/strings.json
+++ b/custom_components/amshan/strings.json
@@ -30,7 +30,7 @@
     },
     "error": {
       "voluptuous_host": "Must be a valid hostname or IP-address",
-      "voluptuous_port": "Must be a valid port number (between 0 and 65353)",
+      "voluptuous_port": "Must be a valid port number (between 0 and 65535)",
       "timeout_connect": "Timeout connecting",
       "timeout_read_frames": "Timeout connecting",
       "cannot_connect": "Failed to connect, please try again",

--- a/custom_components/amshan/translations/en.json
+++ b/custom_components/amshan/translations/en.json
@@ -11,7 +11,7 @@
       "serial_exception_errno_2": "Serial device not found",
       "unknown": "Unexpected error",
       "voluptuous_host": "Must be a valid hostname or IP-address",
-      "voluptuous_port": "Must be a valid port number (between 0 and 65353)"
+      "voluptuous_port": "Must be a valid port number (between 0 and 65535)"
     },
     "step": {
       "network_connection": {


### PR DESCRIPTION
TCP port numbers are represented as 16-bit unsigned integers. Their
range is 0-65535, not 0-65353.

Fixed #7 